### PR TITLE
Support more filetypes, more flexibility for files used

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 I always felt that there wasn't enough UwU in neofetch, so inspired in this amazing [concept](https://www.reddit.com/r/ProgrammerAnimemes/comments/tifm61/yamete_kudasai/) I made a quick dumb script that did it but neater usage wise(not code wise LOL)
 
+Comes with 19 waifus and 6 moans out of the box. Feel free to add your own ASCII waifus or moans (supports most audio formats), as long as you make sure that the titles of the files don't contain a space!
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 I always felt that there wasn't enough UwU in neofetch, so inspired in this amazing [concept](https://www.reddit.com/r/ProgrammerAnimemes/comments/tifm61/yamete_kudasai/) I made a quick dumb script that did it but neater usage wise(not code wise LOL)
 
-Comes with 19 waifus and 6 moans out of the box. Feel free to add your own ASCII waifus or moans (supports most audio formats), as long as you make sure that the titles of the files don't contain a space!
+Comes with 19 ASCII images and 6 moans out of the box. Feel free to add your own ASCII images or sounds (supports most audio formats), as long as you make sure that the titles of the files do not contain a space!
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
@@ -80,9 +80,10 @@ Make sure that your system has mplayer, lolcat and neofetch installed.
 	Append alias to the end of the file
 	
 	```sh
-	alias yamefetch="/home/xzinik/yamefetch/yamefetch.sh"
+	alias yamefetch="/home/$USER/yamefetch/yamefetch.sh"
 	```
-	
+	Don't forget to replace $USER with your desktop username!
+ 
 3. Load new alias
 
    ```sh

--- a/yamefetch.sh
+++ b/yamefetch.sh
@@ -17,15 +17,16 @@ then
 fi
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
-IMG="/img/"
-WAV="/wav/"
-FILES="waifu"
-AUDIOS="iiyada"
-QTTY1=`ls ${SCRIPT_DIR}${IMG} | wc -l`
-QTTY2=`ls ${SCRIPT_DIR}${WAV} | wc -l`
+WAIFU_DIR="${SCRIPT_DIR}/img/"
+IIYADA_DIR="${SCRIPT_DIR}/wav/"
+QTTY1=`ls ${WAIFU_DIR} | wc -l`
+QTTY2=`ls ${IIYADA_DIR} | wc -l`
+WAIFU_FILES=($(ls "${WAIFU_DIR}"))
+IIYADA_FILES=($(ls "${IIYADA_DIR}"))
 RANDOM=$$
 ITEM1=$(($RANDOM%$QTTY1))
 ITEM2=$(($RANDOM%$QTTY2))
-IMG="${SCRIPT_DIR}${IMG}${FILES}${ITEM1}"
-mplayer "${SCRIPT_DIR}${WAV}${AUDIOS}${ITEM2}.wav" </dev/null > /dev/null 2>&1 &
-neofetch --ascii $IMG | lolcat
+WAIFU="${WAIFU_DIR}${WAIFU_FILES[$ITEM1]}"
+IIYADA="${IIYADA_DIR}${IIYADA_FILES[$ITEM2]}"
+mplayer $IIYADA </dev/null > /dev/null 2>&1 &
+neofetch --ascii $WAIFU | lolcat


### PR DESCRIPTION
With these changes, the user can more easily select what files are used and which aren't. Due to these changes, the user is free to add their own ASCII or audio files (not limited to only .wav, but also for instance .mp3), or remove certain ASCII or audio files, to their own liking, without having to bother about file-naming conventions or file types. 

KNOWN ISSUE: files with a file name containing a space are not supported. This is due to the array splitting up the file name into different items.